### PR TITLE
catch error 404 (2.Versuch)

### DIFF
--- a/main.js
+++ b/main.js
@@ -1011,8 +1011,7 @@ function getPlaylistTracks(owner, id, offset, playlistObject) {
     };
     let regParam = `${owner}/playlists/${id}/tracks`;
     let query = {
-        fields: 'total,offset,items(added_at,added_by.id,track(name,id,artists(name,id),duration_ms,album(name,id),disc_number,episode,explicit,popularity))',
-        limit: 100,
+        limit: 50,
         offset: offset
     };
     return sendRequest(`/v1/users/${regParam}?${querystring.stringify(query)}`, 'GET', '')
@@ -1029,8 +1028,8 @@ function getPlaylistTracks(owner, id, offset, playlistObject) {
                     return adapter.log.debug(
                         `There was a playlist track ignored because of missing id; playlist: ${id}; track name: ${trackName}`);
                 }
-                let addedAt = loadOrDefault(item, 'added_at', '');
-                let addedBy = loadOrDefault(item, 'added_by.id', '');
+                let addedAt = loadOrDefault(item, 'addedAt', '');
+                let addedBy = loadOrDefault(item, 'addedBy', '');
                 let trackAlbumId = loadOrDefault(item, 'track.album.id', '');
                 let trackAlbumName = loadOrDefault(item, 'track.album.name', '');
                 let trackDiscNumber = loadOrDefault(item, 'track.disc_number', 1);
@@ -1067,9 +1066,9 @@ function getPlaylistTracks(owner, id, offset, playlistObject) {
                 playlistObject.songs.push(a);
                 i++;
             });
-            if (offset + 100 < data.total) {
+            if (offset + 50 < data.total) {
                 return new Promise(resolve => setTimeout(resolve, 1000))
-                    .then(() => getPlaylistTracks(owner, id, offset + 100, playlistObject));
+                    .then(() => getPlaylistTracks(owner, id, offset + 50, playlistObject));
             } else {
                 return Promise.resolve(playlistObject);
             }


### PR DESCRIPTION
die erste Änderung hatte noch nicht den gewünschten Effekt. Bei der Abfrage nach den Track-Daten scheint sich der Filter geändert zu haben. Laut Beschreibung sollte nach added_at und added_by.id gefiltert werden, in dem request gibt es aber nur addedAt und addedBy. Wenn kein Filter angegeben wird, werden aber alle Daten zurückgegeben. Siehe: `https://developer.spotify.com/documentation/web-api/reference/#/operations/get-playlists-tracks`. 
Ich habe das jetzt 1 Tag so laufen - bisher keine Fehler.