### PR TITLE
stabilize token refresh

### DIFF
--- a/main.js
+++ b/main.js
@@ -99,6 +99,56 @@ const requestQueue = {
 
 const TOKEN_REFRESH_SKEW_MS = 10 * 60 * 1000; // Refresh 10 minutes before expiry
 const TOKEN_REFRESH_MIN_DELAY_MS = 30 * 1000; // Avoid immediate refresh loops
+const TOKEN_REFRESH_RETRY_DELAY_MS = 60 * 1000; // Retry quickly on transient network failures
+
+let refreshTokenInFlight = null;
+
+function getErrorMessage(error) {
+    if (!error) {
+        return '';
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    if (error.message) {
+        return error.message;
+    }
+    return `${error}`;
+}
+
+function isTransientNetworkError(error) {
+    if (!error) {
+        return false;
+    }
+
+    const code = error.code || (error.cause && error.cause.code);
+    const message = getErrorMessage(error).toUpperCase();
+    const transientCodes = new Set([
+        'EAI_AGAIN',
+        'ECONNREFUSED',
+        'ECONNRESET',
+        'ETIMEDOUT',
+        'ENOTFOUND',
+        'EHOSTUNREACH',
+        'ENETUNREACH',
+    ]);
+
+    if (code && transientCodes.has(code)) {
+        return true;
+    }
+
+    return (
+        message.includes('EAI_AGAIN') ||
+        message.includes('ECONNREFUSED') ||
+        message.includes('ECONNRESET') ||
+        message.includes('ETIMEDOUT') ||
+        message.includes('ENOTFOUND') ||
+        message.includes('EHOSTUNREACH') ||
+        message.includes('ENETUNREACH') ||
+        message.includes('SOCKET HANG UP') ||
+        message.includes('TIMEOUT')
+    );
+}
 
 const application = {
     userId: '',
@@ -499,7 +549,27 @@ function scheduleTokenRefresh(expiresAtMs, source) {
         adapter.log.debug('Starting proactive token refresh...');
         refreshToken()
             .then(() => adapter.log.info('Proactive token refresh successful'))
-            .catch(err => adapter.log.error(`Proactive token refresh failed: ${err}`));
+            .catch(err => {
+                adapter.log.error(`Proactive token refresh failed: ${err}`);
+
+                if (isTransientNetworkError(err)) {
+                    adapter.log.warn(
+                        `Proactive token refresh failed due temporary network issue; retrying in ${Math.round(TOKEN_REFRESH_RETRY_DELAY_MS / 1000)}s`,
+                    );
+                    clearTimeout(application.tokenRefreshTimer);
+                    application.tokenRefreshTimer = setTimeout(() => {
+                        if (stopped) {
+                            return;
+                        }
+                        adapter.log.debug('Retrying proactive token refresh after transient network error...');
+                        refreshToken()
+                            .then(() => adapter.log.info('Proactive token refresh retry successful'))
+                            .catch(retryErr =>
+                                adapter.log.error(`Proactive token refresh retry failed: ${retryErr}`),
+                            );
+                    }, TOKEN_REFRESH_RETRY_DELAY_MS);
+                }
+            });
     }, delayMs);
 }
 
@@ -695,6 +765,9 @@ function sendRequestDirect(endpoint, method, sendBody, delayAccepted, tokenRefre
             if (!axiosError.response) {
                 // Network error, DNS error, timeout, etc. - not Spotify's fault
                 adapter.log.error(`network request error on ${endpoint}: ${axiosError.message}`);
+                if (isTransientNetworkError(axiosError)) {
+                    return Promise.reject(503);
+                }
                 return Promise.reject(axiosError);
             }
 
@@ -1943,6 +2016,11 @@ function getToken() {
 }
 
 function refreshToken() {
+    if (refreshTokenInFlight) {
+        adapter.log.debug('Token refresh already running - reusing in-flight refresh request');
+        return refreshTokenInFlight;
+    }
+
     adapter.log.debug('token is requested again');
     const tokenData = new URLSearchParams();
     tokenData.append('grant_type', 'refresh_token');
@@ -1959,49 +2037,60 @@ function refreshToken() {
     };
 
     if (application.refreshToken !== '') {
-        return request(options).then(response => {
-            const statusCode = typeof response.statusCode !== 'undefined' ? response.statusCode : response.status;
-            const body = typeof response.body !== 'undefined' ? response.body : response.data;
-            // this request gets the new token
-            if (statusCode === 200) {
-                adapter.log.debug('new token arrived');
-                let parsedJson;
-                try {
-                    parsedJson = JSON.parse(body);
-                } catch (e) {
-                    parsedJson = {};
-                    adapter.log.info(`Error: ${e}`);
-                }
-                if (!parsedJson.hasOwnProperty.call(parsedJson, 'refresh_token')) {
-                    parsedJson.refresh_token = application.refreshToken;
-                }
-                adapter.log.debug('Token refresh successful');
+        refreshTokenInFlight = request(options)
+            .then(response => {
+                const statusCode = typeof response.statusCode !== 'undefined' ? response.statusCode : response.status;
+                const body = typeof response.body !== 'undefined' ? response.body : response.data;
+                // this request gets the new token
+                if (statusCode === 200) {
+                    adapter.log.debug('new token arrived');
+                    let parsedJson;
+                    if (body && typeof body === 'object') {
+                        parsedJson = body;
+                    } else {
+                        try {
+                            parsedJson = body ? JSON.parse(body) : {};
+                        } catch (e) {
+                            adapter.log.error(`Error parsing token response: ${e}`);
+                            parsedJson = {};
+                        }
+                    }
+                    if (!parsedJson.hasOwnProperty.call(parsedJson, 'refresh_token')) {
+                        parsedJson.refresh_token = application.refreshToken;
+                    }
+                    adapter.log.debug('Token refresh successful');
 
-                return saveToken(parsedJson)
-                    .then(tokenObj => {
-                        application.token = tokenObj.accessToken;
-                        application.refreshToken = tokenObj.refreshToken;
-                        scheduleTokenRefresh(getTokenExpiresAtMs(tokenObj), 'refreshToken');
-                        adapter.log.debug('Token saved and updated in application state');
-                        return tokenObj;
-                    })
-                    .catch(err => {
-                        adapter.log.error(`Error saving token: ${err}`);
-                        return Promise.reject(err);
-                    });
-            }
-            adapter.log.error(`Token refresh failed with status code: ${statusCode}`);
-            return Promise.reject(statusCode);
-        }).catch(error => {
-            adapter.log.error(`Token refresh request failed: ${error.message || error}`);
-            if (error && error.response) {
-                const responseData = error.response.data;
-                adapter.log.error(
-                    `Token refresh response: ${typeof responseData === 'string' ? responseData : JSON.stringify(responseData)}`,
-                );
-            }
-            return Promise.reject(error);
-        });
+                    return saveToken(parsedJson)
+                        .then(tokenObj => {
+                            application.token = tokenObj.accessToken;
+                            application.refreshToken = tokenObj.refreshToken;
+                            scheduleTokenRefresh(getTokenExpiresAtMs(tokenObj), 'refreshToken');
+                            adapter.log.debug('Token saved and updated in application state');
+                            return tokenObj;
+                        })
+                        .catch(err => {
+                            adapter.log.error(`Error saving token: ${err}`);
+                            return Promise.reject(err);
+                        });
+                }
+                adapter.log.error(`Token refresh failed with status code: ${statusCode}`);
+                return Promise.reject(statusCode);
+            })
+            .catch(error => {
+                adapter.log.error(`Token refresh request failed: ${error.message || error}`);
+                if (error && error.response) {
+                    const responseData = error.response.data;
+                    adapter.log.error(
+                        `Token refresh response: ${typeof responseData === 'string' ? responseData : JSON.stringify(responseData)}`,
+                    );
+                }
+                return Promise.reject(error);
+            })
+            .finally(() => {
+                refreshTokenInFlight = null;
+            });
+
+        return refreshTokenInFlight;
     }
 
     adapter.log.warn('Cannot refresh token: no refresh token available');
@@ -2179,7 +2268,7 @@ function pollDeviceApi() {
             scheduleDevicePollingWithOffset();
         })
         .catch(err => {
-            if (err === 401 || err === 429 || err === 500 || err === 502 || err === 503) {
+            if (err === 401 || err === 429 || err === 500 || err === 502 || err === 503 || err === 504) {
                 // Keep polling running for temporary errors
                 if (err === 401) {
                     adapter.log.warn('Device polling: 401 Unauthorized - token refresh should be in progress, continuing polling');
@@ -2816,6 +2905,10 @@ function listenOnHtmlDevices() {
 //If started as allInOne/compact mode => return function to create instance
 if (module && module.parent) {
     module.exports = startAdapter;
+    module.exports.__test = {
+        getErrorMessage,
+        isTransientNetworkError,
+    };
 } else {
     // or start the instance directly
     startAdapter();

--- a/test/mocha.setup.js
+++ b/test/mocha.setup.js
@@ -6,9 +6,15 @@ process.on('unhandledRejection', (e) => {
 // enable the should interface with sinon
 // and load chai-as-promised and sinon-chai by default
 const sinonChai = require('sinon-chai');
-const chaiAsPromised = require('chai-as-promised');
 const { should, use } = require('chai');
+const chaiAsPromised = require('chai-as-promised');
 
 should();
-use(sinonChai);
-use(chaiAsPromised);
+if (typeof sinonChai === 'function') {
+    use(sinonChai);
+}
+if (chaiAsPromised.default) {
+    use(chaiAsPromised.default);
+} else if (typeof chaiAsPromised === 'function') {
+    use(chaiAsPromised);
+}

--- a/test/testNetworkErrorDetection.js
+++ b/test/testNetworkErrorDetection.js
@@ -1,0 +1,119 @@
+// Simple unit test for transient error detection helpers
+// These functions are extracted from main.js for testing
+
+const { expect } = require('chai');
+
+// Copy of the helper functions from main.js to test in isolation
+function getErrorMessage(error) {
+    if (!error) {
+        return '';
+    }
+    if (typeof error === 'string') {
+        return error;
+    }
+    if (error.message) {
+        return error.message;
+    }
+    return `${error}`;
+}
+
+function isTransientNetworkError(error) {
+    if (!error) {
+        return false;
+    }
+
+    const code = error.code || (error.cause && error.cause.code);
+    const message = getErrorMessage(error).toUpperCase();
+    const transientCodes = new Set([
+        'EAI_AGAIN',
+        'ECONNREFUSED',
+        'ECONNRESET',
+        'ETIMEDOUT',
+        'ENOTFOUND',
+        'EHOSTUNREACH',
+        'ENETUNREACH',
+    ]);
+
+    if (code && transientCodes.has(code)) {
+        return true;
+    }
+
+    return (
+        message.includes('EAI_AGAIN') ||
+        message.includes('ECONNREFUSED') ||
+        message.includes('ECONNRESET') ||
+        message.includes('ETIMEDOUT') ||
+        message.includes('ENOTFOUND') ||
+        message.includes('EHOSTUNREACH') ||
+        message.includes('ENETUNREACH') ||
+        message.includes('SOCKET HANG UP') ||
+        message.includes('TIMEOUT')
+    );
+}
+
+describe('Transient network error detection (isolated)', () => {
+    it('detects code-based transient DNS errors (EAI_AGAIN)', () => {
+        const err = new Error('getaddrinfo EAI_AGAIN accounts.spotify.com');
+        err.code = 'EAI_AGAIN';
+
+        expect(isTransientNetworkError(err)).to.equal(true);
+    });
+
+    it('detects message-based transient connection errors (ECONNREFUSED)', () => {
+        const err = new Error('queryA ECONNREFUSED api.spotify.com');
+
+        expect(isTransientNetworkError(err)).to.equal(true);
+    });
+
+    it('detects timeout errors (ETIMEDOUT)', () => {
+        const err = new Error('Connection timeout');
+        err.code = 'ETIMEDOUT';
+
+        expect(isTransientNetworkError(err)).to.equal(true);
+    });
+
+    it('detects connection reset errors', () => {
+        const err = new Error('socket hang up');
+
+        expect(isTransientNetworkError(err)).to.equal(true);
+    });
+
+    it('detects ENOTFOUND DNS errors', () => {
+        const err = new Error('getaddrinfo ENOTFOUND api.spotify.com');
+        err.code = 'ENOTFOUND';
+
+        expect(isTransientNetworkError(err)).to.equal(true);
+    });
+
+    it('does not classify auth failures as transient network errors', () => {
+        const err = new Error('Request failed with status code 401');
+
+        expect(isTransientNetworkError(err)).to.equal(false);
+    });
+
+    it('does not classify Spotify API errors as transient network errors', () => {
+        const err = new Error('Bad Request');
+        err.statusCode = 400;
+
+        expect(isTransientNetworkError(err)).to.equal(false);
+    });
+
+    it('returns safe string message for string errors', () => {
+        expect(getErrorMessage('simple error message')).to.equal('simple error message');
+    });
+
+    it('returns safe string message for Error objects', () => {
+        const err = new Error('test error message');
+        expect(getErrorMessage(err)).to.equal('test error message');
+    });
+
+    it('returns empty string for null/undefined errors', () => {
+        expect(getErrorMessage(null)).to.equal('');
+        expect(getErrorMessage(undefined)).to.equal('');
+    });
+
+    it('handles errors without message property', () => {
+        const err = { code: 'ECONNREFUSED' };
+        expect(isTransientNetworkError(err)).to.equal(true);
+    });
+});


### PR DESCRIPTION
- Added transient network error detection (e.g. EAI_AGAIN, ECONNREFUSED, ETIMEDOUT, DNS/socket timeout patterns).
- Improved proactive token refresh behavior with retry logic on transient failures.
- Prevented parallel token refresh calls by reusing one in-flight refresh promise.
- Improved refresh response handling and logging for clearer diagnostics.
- Extended temporary-error polling tolerance to include 504 in addition to existing retryable status codes.
- Exported helper functions for testability in module mode.
- Added dedicated tests for transient network error classification.
- Made test setup plugin loading more robust for chai-as-promised/sinon-chai compatibility.